### PR TITLE
Add QR scanning to confirm shipments

### DIFF
--- a/VEKTA/03 Views/RoleViews/SellerViews/Orders/ManualShipmentInputView.swift
+++ b/VEKTA/03 Views/RoleViews/SellerViews/Orders/ManualShipmentInputView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct ManualShipmentInputView: View {
+    @Environment(\.presentationMode) var presentationMode
+    @State private var shipmentId: String = ""
+    let onSubmit: (String) -> Void
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                TextField("ID приемки", text: $shipmentId)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding()
+
+                Button("Найти") {
+                    onSubmit(shipmentId)
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .disabled(shipmentId.isEmpty)
+                .frame(maxWidth: .infinity)
+                .frame(height: 50)
+                .background(Color.brandGreen)
+                .foregroundColor(.white)
+                .cornerRadius(12)
+                .padding()
+
+                Spacer()
+            }
+            .navigationTitle("Поиск приемки")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Закрыть") {
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/VEKTA/03 Views/RoleViews/SellerViews/Orders/WarehouseReceivingView.swift
+++ b/VEKTA/03 Views/RoleViews/SellerViews/Orders/WarehouseReceivingView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import FirebaseFirestore
-import AVFoundation
 
 // MARK: - Warehouse Receiving View
 struct WarehouseReceivingView: View {
@@ -62,8 +61,8 @@ struct WarehouseReceivingView: View {
             .navigationTitle("Приемка товаров")
             .sheet(isPresented: $showingScanner) {
                 QRScannerView { qrCode in
-                    viewModel.processQRCode(qrCode)
                     showingScanner = false
+                    viewModel.confirmReception(for: qrCode)
                 }
             }
             .sheet(isPresented: $showingManualInput) {
@@ -74,6 +73,16 @@ struct WarehouseReceivingView: View {
             }
             .sheet(item: $selectedShipment) { shipment in
                 ShipmentDetailView(shipment: shipment)
+            }
+            .alert("Ошибка", isPresented: .constant(viewModel.errorMessage != nil)) {
+                Button("OK") { viewModel.errorMessage = nil }
+            } message: {
+                Text(viewModel.errorMessage ?? "")
+            }
+            .alert("Успех", isPresented: .constant(viewModel.successMessage != nil)) {
+                Button("OK") { viewModel.successMessage = nil }
+            } message: {
+                Text(viewModel.successMessage ?? "")
             }
         }
         .onAppear {

--- a/VEKTA/03 Views/RoleViews/SellerViews/Orders/WarehouseReceivingViewModel.swift
+++ b/VEKTA/03 Views/RoleViews/SellerViews/Orders/WarehouseReceivingViewModel.swift
@@ -1,0 +1,69 @@
+import Foundation
+import SwiftUI
+import FirebaseFirestore
+import FirebaseAuth
+
+final class WarehouseReceivingViewModel: ObservableObject {
+    @Published var shipments: [ShipmentModel] = []
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+    @Published var successMessage: String?
+
+    private let db = Firestore.firestore()
+
+    var pendingCount: Int {
+        shipments.filter { $0.status == .created }.count
+    }
+
+    var processingCount: Int {
+        shipments.filter { $0.status == .processing }.count
+    }
+
+    var completedCount: Int {
+        shipments.filter { $0.status == .ready || $0.status == .delivered }.count
+    }
+
+    func loadShipments() {
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        isLoading = true
+        db.collection("shipments")
+            .whereField("warehouseId", isEqualTo: uid)
+            .whereField("type", isEqualTo: ShipmentType.incoming.rawValue)
+            .getDocuments { [weak self] snapshot, error in
+                DispatchQueue.main.async {
+                    self?.isLoading = false
+                    if let error = error {
+                        self?.errorMessage = error.localizedDescription
+                    } else {
+                        self?.shipments = snapshot?.documents.compactMap { try? $0.data(as: ShipmentModel.self) } ?? []
+                    }
+                }
+            }
+    }
+
+    func confirmReception(for code: String) {
+        guard let shipment = shipments.first(where: { $0.qrCode == code || $0.id == code }) else {
+            errorMessage = "Приемка не найдена"
+            return
+        }
+        updateShipmentStatus(shipmentId: shipment.id ?? "")
+    }
+
+    private func updateShipmentStatus(shipmentId: String) {
+        isLoading = true
+        db.collection("shipments").document(shipmentId).updateData([
+            "status": ShipmentStatus.processing.rawValue,
+            "updatedAt": Date()
+        ]) { [weak self] error in
+            DispatchQueue.main.async {
+                self?.isLoading = false
+                if let error = error {
+                    self?.errorMessage = error.localizedDescription
+                } else {
+                    self?.successMessage = "Приемка подтверждена"
+                    self?.loadShipments()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `WarehouseReceivingViewModel` to load shipments and confirm reception
- allow manual ID entry via new `ManualShipmentInputView`
- hook up QR scanning to call `confirmReception(for:)`
- display success and error alerts when confirming reception

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856c83673788325894dd8768044d7f7