### PR TITLE
Add Delivery detail view with SMS confirmation

### DIFF
--- a/VEKTA/03 Views/RoleViews/Courier/DeliveryDetailView.swift
+++ b/VEKTA/03 Views/RoleViews/Courier/DeliveryDetailView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+class DeliveryDetailViewModel: ObservableObject {
+    func sendSmsCode(orderId: String) {
+        // Здесь будет вызов API Kaspi для отправки SMS через заглушку
+        print("📲 Отправляем SMS-код для заказа: \(orderId)")
+    }
+
+    func markDelivered(orderId: String, smsCode: String) {
+        // Здесь будет подтверждение доставки через API
+        print("✅ Подтверждаем доставку заказа \(orderId) с кодом \(smsCode)")
+    }
+}
+
+struct DeliveryDetailView: View {
+    let orderId: String
+    @StateObject private var viewModel = DeliveryDetailViewModel()
+
+    @State private var showSmsAlert = false
+    @State private var smsCode = ""
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Детали заказа \(orderId)")
+                .font(.title2)
+
+            Button("Отправить клиенту SMS-код") {
+                viewModel.sendSmsCode(orderId: orderId)
+            }
+            .font(.headline)
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(Color.kaspiBlue)
+            .foregroundColor(.white)
+            .cornerRadius(12)
+
+            Button("Подтвердить доставку") {
+                showSmsAlert = true
+            }
+            .font(.headline)
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(Color.brandGreen)
+            .foregroundColor(.white)
+            .cornerRadius(12)
+            .alert("Введите SMS-код", isPresented: $showSmsAlert) {
+                TextField("0000", text: $smsCode)
+                    .keyboardType(.numberPad)
+                Button("Подтвердить") {
+                    viewModel.markDelivered(orderId: orderId, smsCode: smsCode)
+                    smsCode = ""
+                }
+                Button("Отмена", role: .cancel) {}
+            }
+        }
+        .padding()
+        .navigationTitle("Доставка")
+    }
+}
+
+struct DeliveryDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            DeliveryDetailView(orderId: "123456")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `DeliveryDetailView` with ViewModel for couriers
- allow sending SMS code and confirming delivery via alert

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6856c899b5c0832587ebdb0096524159