### PR TITLE
Add Firebase functions for Kaspi SMS

### DIFF
--- a/firebase-functions/README.md
+++ b/firebase-functions/README.md
@@ -1,0 +1,24 @@
+# Firebase Cloud Functions: SMS via Kaspi API
+
+This folder contains sample Firebase Cloud Functions that send and confirm SMS codes using the Kaspi API.
+
+## Configuration
+
+Set the following runtime config variables:
+
+```bash
+firebase functions:config:set kaspi.url="https://kaspi.example.com/api" kaspi.token="YOUR_TOKEN"
+```
+
+Deploy functions:
+
+```bash
+firebase deploy --only functions
+```
+
+## Available Functions
+
+- `sendSmsCode`: Callable function to send an SMS code to a user.
+- `confirmSmsCode`: Callable function to confirm a previously sent code.
+
+Both functions expect JSON parameters when invoked.

--- a/firebase-functions/index.js
+++ b/firebase-functions/index.js
@@ -1,0 +1,58 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+const axios = require('axios');
+
+admin.initializeApp();
+
+/**
+ * sendSmsCode Firebase Cloud Function
+ * Triggers: callable
+ * Params: phoneNumber (string)
+ */
+exports.sendSmsCode = functions.https.onCall(async (data, context) => {
+  const phoneNumber = data.phoneNumber;
+  if (!phoneNumber) {
+    throw new functions.https.HttpsError('invalid-argument', 'phoneNumber is required');
+  }
+  const code = Math.floor(100000 + Math.random() * 900000).toString();
+
+  const kaspiApiUrl = functions.config().kaspi.url;
+  const kaspiToken = functions.config().kaspi.token;
+
+  try {
+    await axios.post(`${kaspiApiUrl}/sendSms`, { phone: phoneNumber, code }, {
+      headers: { Authorization: `Bearer ${kaspiToken}` }
+    });
+    // optionally store verification code using admin.firestore() or other service
+    return { status: 'sent' };
+  } catch (err) {
+    console.error('sendSmsCode error', err);
+    throw new functions.https.HttpsError('internal', 'Failed to send SMS');
+  }
+});
+
+/**
+ * confirmSmsCode Firebase Cloud Function
+ * Triggers: callable
+ * Params: phoneNumber (string), code (string)
+ */
+exports.confirmSmsCode = functions.https.onCall(async (data, context) => {
+  const phoneNumber = data.phoneNumber;
+  const code = data.code;
+  if (!phoneNumber || !code) {
+    throw new functions.https.HttpsError('invalid-argument', 'phoneNumber and code are required');
+  }
+
+  const kaspiApiUrl = functions.config().kaspi.url;
+  const kaspiToken = functions.config().kaspi.token;
+
+  try {
+    const res = await axios.post(`${kaspiApiUrl}/confirmSms`, { phone: phoneNumber, code }, {
+      headers: { Authorization: `Bearer ${kaspiToken}` }
+    });
+    return res.data;
+  } catch (err) {
+    console.error('confirmSmsCode error', err);
+    throw new functions.https.HttpsError('internal', 'Failed to confirm SMS');
+  }
+});

--- a/firebase-functions/package.json
+++ b/firebase-functions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "firebase-functions",
+  "description": "Firebase Cloud Functions for SMS using Kaspi API",
+  "version": "1.0.0",
+  "main": "index.js",
+  "engines": {"node": "18"},
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1",
+    "axios": "^1.4.0"
+  }
+}


### PR DESCRIPTION
## Summary
- provide Firebase Cloud Function template for sending and verifying SMS codes through Kaspi API

## Testing
- `npm install --prefix firebase-functions` *(fails: 403 Forbidden due to network restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_6856ca6aca748325b60f042015075415